### PR TITLE
Filter course search results to Massachusetts only

### DIFF
--- a/tools/courses.py
+++ b/tools/courses.py
@@ -46,7 +46,11 @@ def search_course(name: str) -> dict | None:
         if not courses:
             print(f"No results found for: {name}")
             return None
-        return courses[0]
+        for course in courses:
+            if course.get("state") == "MA":
+                return course
+        print(f"No Massachusetts match found for: {name}")
+        return None
     except requests.RequestException as e:
         print(f"Error fetching {name}: {e}")
         return None


### PR DESCRIPTION
## What
- Updated `search_course()` in `tools/courses.py` to iterate over all search results instead of taking the first match
- Returns the first result where `state == "MA"`
- Logs a warning and returns `None` if no Massachusetts match is found

## Why
We only want to support Massachusetts courses. Previously the script would take the top search result regardless of state, risking pulling in courses from other states with similar names.

## How to test
- [ ] Run `python tools/courses.py` and verify only MA courses are fetched
- [ ] Temporarily add a non-MA course name to `COURSES` and confirm a warning is printed and it is skipped

Generated with Claude Code